### PR TITLE
fix: set default num_members to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "so"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "so"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Open a Slack channel using slack://... or https://app.slack.com/... to prevent Slack from leaving the redirect tab open in your browser."
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ async fn main() -> Result<()> {
 
             let channels = results
                 .iter()
-                .filter(|channel| channel.num_members.unwrap_or(0) > 0)
+                .filter(|channel| channel.num_members.unwrap_or(1) > 0)
                 .map(|channel| {
                     (ChannelName::from_str(channel.name.as_str()).unwrap(), channel.id.clone())
                 })


### PR DESCRIPTION
Sometimes the `conversations.list` API returns no `num_members` for unknown reasons. This helps prevent important channels from being excluded.
